### PR TITLE
Update head.html with MathJax snippet

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,4 +8,8 @@
 
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+  <!-- Math -->
+    <script type="text/javascript"
+      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+    </script>    
 </head>


### PR DESCRIPTION
You can have in-line LaTeX equations with the `\\( \beta \\)` syntax in kramdown if this snippet is in head.html. I got the idea [here](http://gastonsanchez.com/opinion/2014/02/16/Mathjax-with-jekyll/).